### PR TITLE
Add additional dictionary operations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/defoeam/kvs
 
-go 1.19
+go 1.21
 
 require github.com/gin-gonic/gin v1.10.0
 

--- a/kv/keyvaluestore.go
+++ b/kv/keyvaluestore.go
@@ -76,5 +76,4 @@ func (kv *KeyValueStore) Clear() {
 	for k := range kv.data {
 		delete(kv.data, k)
 	}
-
 }

--- a/kv/keyvaluestore.go
+++ b/kv/keyvaluestore.go
@@ -42,11 +42,31 @@ func (kv *KeyValueStore) GetAll() map[string]string {
 	kv.mu.RLock()
 	defer kv.mu.RUnlock()
 
-	// log.Printf("size of data is %d\n", len(kv.data))
-	res := maps.Clone(kv.data)
-	// log.Printf("size of res is %d\n", len(res))
+	return maps.Clone(kv.data)
+}
 
-	return res
+func (kv *KeyValueStore) GetKeys() []string {
+	kv.mu.RLock()
+	defer kv.mu.RUnlock()
+
+	keys := make([]string, 0, len(kv.data))
+	for k := range kv.data {
+		keys = append(keys, k)
+	}
+
+	return keys
+}
+
+func (kv *KeyValueStore) GetValues() []string {
+	kv.mu.RLock()
+	defer kv.mu.RUnlock()
+
+	values := make([]string, 0, len(kv.data))
+	for _, v := range kv.data {
+		values = append(values, v)
+	}
+
+	return values
 }
 
 func (kv *KeyValueStore) Clear() {

--- a/kv/keyvaluestore.go
+++ b/kv/keyvaluestore.go
@@ -48,3 +48,13 @@ func (kv *KeyValueStore) GetAll() map[string]string {
 
 	return res
 }
+
+func (kv *KeyValueStore) Clear() {
+	kv.mu.Lock()
+	defer kv.mu.Unlock()
+
+	for k := range kv.data {
+		delete(kv.data, k)
+	}
+
+}

--- a/kv/keyvaluestore.go
+++ b/kv/keyvaluestore.go
@@ -1,6 +1,8 @@
 package keyvaluestore
 
 import (
+	"log"
+	"maps"
 	"sync"
 )
 
@@ -21,6 +23,8 @@ func NewKeyValueStore() *KeyValueStore {
 func (kv *KeyValueStore) Set(key string, value string) {
 	kv.mu.Lock()
 	defer kv.mu.Unlock()
+
+	log.Printf("Adding \"%s\" to kvs", key)
 	kv.data[key] = value
 }
 
@@ -28,6 +32,19 @@ func (kv *KeyValueStore) Set(key string, value string) {
 func (kv *KeyValueStore) Get(key string) (string, bool) {
 	kv.mu.RLock()
 	defer kv.mu.RUnlock()
+
 	val, ok := kv.data[key]
 	return val, ok
+}
+
+// GetAll retries all key-values pairs from the store.
+func (kv *KeyValueStore) GetAll() map[string]string {
+	kv.mu.RLock()
+	defer kv.mu.RUnlock()
+
+	// log.Printf("size of data is %d\n", len(kv.data))
+	res := maps.Clone(kv.data)
+	// log.Printf("size of res is %d\n", len(res))
+
+	return res
 }

--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ handleGetAll returns a gin.HandlerFunc that retrieves all key-values in the stor
 
 Example request:
 
-	GET /get
+	GET /items
 
 Example response:
 
@@ -67,7 +67,7 @@ If the key is missing or not found, it responds with an appropriate HTTP status 
 
 Example Request:
 
-	GET /get/:key
+	GET /items/:key
 
 Example Response:
 
@@ -107,7 +107,7 @@ The key and value are provided in the JSON request body. It responds with the cr
 
 Example Request:
 
-	POST /set
+	POST /items
 	{
 	   "key": "exampleKey",
 	   "value": "exampleValue"
@@ -140,12 +140,28 @@ func handleSet(kv *keyvaluestore.KeyValueStore) gin.HandlerFunc {
 	}
 }
 
+// handleClear removes all items from the store.
 func handleClear(kv *keyvaluestore.KeyValueStore) gin.HandlerFunc {
 	return func(ctx *gin.Context) {
 		kv.Clear()
 		ctx.Status(http.StatusNoContent)
 	}
 }
+
+/*
+handleGetKeys gets all keys from the store.
+
+Example Request:
+
+	GET /keys
+
+Example Response:
+
+	[
+		"exampleKey1",
+		"exampleKey2"
+	]
+*/
 
 func handleGetKeys(kv *keyvaluestore.KeyValueStore) gin.HandlerFunc {
 	return func(ctx *gin.Context) {
@@ -154,6 +170,20 @@ func handleGetKeys(kv *keyvaluestore.KeyValueStore) gin.HandlerFunc {
 	}
 }
 
+/*
+handleGetValues returns all values from the store.
+
+Example Request:
+
+	GET /values
+
+Example Response:
+
+	[
+		"exampleValue1",
+		"exampleValue2"
+	]
+*/
 func handleGetValues(kv *keyvaluestore.KeyValueStore) gin.HandlerFunc {
 	return func(ctx *gin.Context) {
 		values := kv.GetValues()
@@ -169,14 +199,16 @@ func main() {
 	router := gin.Default()
 
 	// GET endpoints
-	router.GET("/get", handleGetAll(kv))
-	router.GET("/get/:key", handleGet(kv))
+	router.GET("/items", handleGetAll(kv))
+	router.GET("/items/:key", handleGet(kv))
 	router.GET("/keys", handleGetKeys(kv))
 	router.GET("/values", handleGetValues(kv))
 
 	// POST endpoints
-	router.POST("/set", handleSet(kv))
-	router.POST("/clear", handleClear(kv))
+	router.POST("/items", handleSet(kv))
+
+	// DELETE endpoints
+	router.DELETE("/items", handleClear(kv))
 
 	// Get address
 	port := 8080

--- a/main.go
+++ b/main.go
@@ -140,6 +140,13 @@ func handleSet(kv *keyvaluestore.KeyValueStore) gin.HandlerFunc {
 	}
 }
 
+func handleClear(kv *keyvaluestore.KeyValueStore) gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		kv.Clear()
+		ctx.Status(http.StatusNoContent)
+	}
+}
+
 func main() {
 	// Create a new instance of KeyValueStore.
 	kv := keyvaluestore.NewKeyValueStore()
@@ -153,6 +160,7 @@ func main() {
 
 	// POST endpoints
 	router.POST("/set", handleSet(kv))
+	router.POST("/clear", handleClear(kv))
 
 	// Get address
 	port := 8080

--- a/main.go
+++ b/main.go
@@ -147,6 +147,20 @@ func handleClear(kv *keyvaluestore.KeyValueStore) gin.HandlerFunc {
 	}
 }
 
+func handleGetKeys(kv *keyvaluestore.KeyValueStore) gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		keys := kv.GetKeys()
+		ctx.JSON(http.StatusOK, keys)
+	}
+}
+
+func handleGetValues(kv *keyvaluestore.KeyValueStore) gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		values := kv.GetValues()
+		ctx.JSON(http.StatusOK, values)
+	}
+}
+
 func main() {
 	// Create a new instance of KeyValueStore.
 	kv := keyvaluestore.NewKeyValueStore()
@@ -157,6 +171,8 @@ func main() {
 	// GET endpoints
 	router.GET("/get", handleGetAll(kv))
 	router.GET("/get/:key", handleGet(kv))
+	router.GET("/keys", handleGetKeys(kv))
+	router.GET("/values", handleGetValues(kv))
 
 	// POST endpoints
 	router.POST("/set", handleSet(kv))


### PR DESCRIPTION
Add operations to the key-value store:

- `GetAll`
- `GetKeys`
- `GetValues`
- `Clear`

Renamed endpoints to make distinction between endpoints more clear.
Update go version to 1.21 so that I can use the `maps` package.